### PR TITLE
feat: base layout and navigation (issue #1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -140,6 +140,17 @@
           <div class="integration-grid"><span class="integration-chip">GitHub Pages</span><span class="integration-chip">Claude GitHub Actions</span></div>
         </section>
 
+        <section class="contact-section" id="contact" data-testid="contact-section">
+          <div class="section-header"><div class="section-label">Contact</div><h2 class="section-title">Get in touch</h2></div>
+          <div class="contact-inner">
+            <p class="contact-desc">Have a question or want to learn more? Reach out and we'll get back to you.</p>
+            <form class="contact-form" data-testid="contact-form" onsubmit="return false;">
+              <input class="contact-input" type="email" placeholder="Your email" aria-label="Email address" />
+              <button class="btn-primary" type="submit">Send Message</button>
+            </form>
+          </div>
+        </section>
+
         <section class="cta-section" id="primary-cta">
           <div class="cta-inner">
             <h2>Ready to build?</h2>

--- a/styles.css
+++ b/styles.css
@@ -211,6 +211,20 @@ body {
 }
 .integration-chip:hover { border-color: color-mix(in srgb, var(--accent) 25%, transparent); transform: translateY(-1px); }
 
+/* Contact */
+.contact-section {
+  margin-top: 16px; padding: 36px; background: var(--surface);
+  border: 1px solid rgba(0,0,0,0.06); border-radius: var(--radius-lg);
+}
+.contact-desc { font-size: 14px; color: var(--muted); margin-bottom: 20px; line-height: 1.6; }
+.contact-form { display: flex; gap: 10px; flex-wrap: wrap; }
+.contact-input {
+  flex: 1; min-width: 200px; padding: 11px 16px; border-radius: 10px;
+  border: 1px solid rgba(0,0,0,0.12); background: white; font-size: 13px;
+  font-family: inherit; outline: none; transition: border-color 0.2s;
+}
+.contact-input:focus { border-color: var(--accent); }
+
 /* CTA */
 .cta-section { margin-top: 16px; }
 .cta-inner {


### PR DESCRIPTION
Closes #1

Completes the navigation scaffold by adding the missing #contact section that primary-nav links to, along with matching contact section styling for the editorial warmth direction.

Generated with Claude Code.